### PR TITLE
added a function to retrieve a user's MailChimp member rating

### DIFF
--- a/components/class-go-mailchimp.php
+++ b/components/class-go-mailchimp.php
@@ -238,7 +238,7 @@ class GO_MailChimp
 
 		// in our set up the user is generally only subscribed to one list
 		// so we just pick the rating from the first list in the user meta
-		foreach( $usermeta as $list_info )
+		foreach ( $usermeta as $list_info )
 		{
 			if ( empty( $list_info['member_rating'] ) )
 			{


### PR DESCRIPTION
the member rating is stored in an array keyed to a MC list id, so we're not able to use `go-syncuser`'s `user_meta_subkey()` function directly and have to resort to this.

in support of https://github.com/GigaOM/legacy-pro/issues/3858
