### PR TITLE
handle do_not_email user profile property change in a more generic way

### DIFF
--- a/components/class-go-mailchimp-api.php
+++ b/components/class-go-mailchimp-api.php
@@ -248,8 +248,11 @@ class GO_Mailchimp_API
 		{
 			$inserting[ 'unsubscribed' ] = $unsubscribed;
 			// if someone has unsubscribed from any of our lists, let's flag
-			// them as do not email
-			do_action( 'go_user_profile_do_not_email', $user->ID, TRUE );
+			// them as do not email if they're not already
+			if ( ! $this->do_not_email( $user->ID ) )
+			{
+				do_action( 'go_user_profile_do_not_email', $user->ID, TRUE );
+			}
 		}//END if
 
 		// suspend user update triggers
@@ -392,11 +395,6 @@ class GO_Mailchimp_API
 		if ( empty( $user->user_email ) || empty( $list_id ) )
 		{
 			apply_filters( 'go_slog', 'go-mailchimp', __FUNCTION__ . ': Invalid email or list id passed in.' );
-			return FALSE;
-		}
-
-		if ( $this->do_not_email( $user->ID ) )
-		{
 			return FALSE;
 		}
 

--- a/components/class-go-mailchimp.php
+++ b/components/class-go-mailchimp.php
@@ -159,13 +159,19 @@ class GO_MailChimp
 	 */
 	public function do_not_email_updated( $user_id, $do_not_email )
 	{
-		// we can only act if $do_not_email is FALSE and we have a valid $user_id
-		if ( $do_not_email || 0 >= $user_id )
+		if ( 0 >= $user_id )
 		{
 			return;
 		}
 
-		$this->api()->subscribe( $user_id );
+		if ( $do_not_email )
+		{
+			$this->api()->unsubscribe( $user_id );
+		}
+		else
+		{
+			$this->api()->subscribe( $user_id );
+		}
 	}//END do_not_email_updated
 
 	/**


### PR DESCRIPTION
- removed the assumption that unsubscription request always come from the MailChimp webhook. this will allow go-mailchimp to unsubscribe user as a result of setting the do_not_email user profile to `TRUE`
- also allow a user to be resubscribed if the `do_not_email` flag is set back to FALSE

related to https://github.com/GigaOM/legacy-pro/issues/3858
